### PR TITLE
Fixed typo generating warnings

### DIFF
--- a/lib/metabox/init.php
+++ b/lib/metabox/init.php
@@ -758,7 +758,7 @@ class cmb_Meta_Box {
 		if ( is_string( $meta_box['pages'] ) )
 			$type = $meta_box['pages'];
 		// if it's an array of one, extract it
-		elseif ( is_array( $meta_box['pages'] ) && count( $meta_box['pages'] === 1 ) )
+		elseif ( is_array( $meta_box['pages'] ) && count( $meta_box['pages'] ) === 1 )
 			$type = is_string( end( $meta_box['pages'] ) ) ? end( $meta_box['pages'] ) : false;
 
 		if ( !$type )


### PR DESCRIPTION
Similar to https://github.com/WebDevStudios/Custom-Metaboxes-and-Fields-for-WordPress/pull/767,

Half of our apache error log is this warning. Among other times it occurs when trying to register a new user which fails. This is probably completely unrelated though.